### PR TITLE
include xerces/XMLFormatter

### DIFF
--- a/src/petardfs.cpp
+++ b/src/petardfs.cpp
@@ -61,7 +61,7 @@ using namespace std;
 #include <xercesc/sax/InputSource.hpp>
 #include <xercesc/util/PlatformUtils.hpp>
 #include <xercesc/util/XMLString.hpp>
-#include <xercesc/util/XMLString.hpp>
+#include <xercesc/framework/XMLFormatter.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/framework/LocalFileInputSource.hpp>


### PR DESCRIPTION
This includes XMLFormatter in petardfs.cpp

Without it compilation fails:

```
Making all in src                                                                                                                                                                                      
make[2]: Entering directory '/media/user/user/bck/src/petardfs/src'                                                                                                                                    
g++ -DHAVE_CONFIG_H -I. -I..  -DFUSE_USE_VERSION=25 -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse -I. -I. -I.. -I.. -I/usr/local/include -g -O2 -g -O2 -I/usr/local/include
-g -O2 -MT petardfs-petardfs.o -MD -MP -MF .deps/petardfs-petardfs.Tpo -c -o petardfs-petardfs.o `test -f 'petardfs.cpp' || echo './'`petardfs.cpp
petardfs.cpp:64:10: fatal error: xercesc/XMLFormatter.hpp: No such file or directory
 #include <xercesc/XMLFormatter.hpp>                                           
          ^~~~~~~~~~~~~~~~~~~~~~~~~~                           
compilation terminated.                                                                                                                                                                               
make[2]: *** [Makefile:473: petardfs-petardfs.o] Error 1                                                                                                                                              
```